### PR TITLE
feat(GD-Q9F3B7): Add dash to player

### DIFF
--- a/third-person-controllers/project.godot
+++ b/third-person-controllers/project.godot
@@ -79,3 +79,9 @@ jump={
 , Object(InputEventJoypadButton,"resource_local_to_scene":false,"resource_name":"","device":-1,"button_index":0,"pressure":0.0,"pressed":false,"script":null)
 ]
 }
+dash={
+"deadzone": 0.2,
+"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":4194325,"key_label":0,"unicode":0,"location":0,"echo":false,"script":null)
+, Object(InputEventJoypadButton,"resource_local_to_scene":false,"resource_name":"","device":-1,"button_index":9,"pressure":0.0,"pressed":false,"script":null)
+]
+}

--- a/third-person-controllers/state-machine/state.gd
+++ b/third-person-controllers/state-machine/state.gd
@@ -13,7 +13,14 @@ func _do_physics_process(delta: float) -> void:
 	pass
 
 func _enter(previous_state_path: String, data := {}) -> void:
-	pass
+	var delta = data.get("delta")
+	var event = data.get("event")
+	var func_name = data.get("func")
+	print("Base _enter: delta=%s event=%s, func_name=%s" % [delta, event, func_name])
+	match func_name:
+		"_do_unhandled_input" when event: _do_unhandled_input(event)
+		"_do_process" when delta: _do_process(delta)
+		"_do_physics_process" when delta: _do_physics_process(delta)
 
 func _exit() -> void:
 	pass

--- a/third-person-controllers/state-machine/state.gd
+++ b/third-person-controllers/state-machine/state.gd
@@ -16,7 +16,7 @@ func _enter(previous_state_path: String, data := {}) -> void:
 	var delta = data.get("delta")
 	var event = data.get("event")
 	var func_name = data.get("func")
-	print("Base _enter: delta=%s event=%s, func_name=%s" % [delta, event, func_name])
+	# print("Base _enter: delta=%s event=%s, func_name=%s" % [delta, event, func_name])
 	match func_name:
 		"_do_unhandled_input" when event: _do_unhandled_input(event)
 		"_do_process" when delta: _do_process(delta)

--- a/third-person-controllers/third-person-controller/demo.tscn
+++ b/third-person-controllers/third-person-controller/demo.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=6 format=3 uid="uid://dnajd06eujhut"]
+[gd_scene load_steps=8 format=3 uid="uid://dnajd06eujhut"]
 
 [ext_resource type="Script" uid="uid://dxsjn015y824s" path="res://third-person-controller/demo.gd" id="1_ss3lw"]
 [ext_resource type="PackedScene" uid="uid://oxyumaw1iadk" path="res://third-person-controller/third-person-controller.tscn" id="1_vyiun"]
@@ -18,6 +18,13 @@ sky = SubResource("Sky_vyiun")
 tonemap_mode = 2
 glow_enabled = true
 
+[sub_resource type="PlaceholderTexture2D" id="PlaceholderTexture2D_ss3lw"]
+
+[sub_resource type="StandardMaterial3D" id="StandardMaterial3D_woynx"]
+albedo_color = Color(2.79158e-06, 0.406329, 0.679828, 1)
+albedo_texture = SubResource("PlaceholderTexture2D_ss3lw")
+roughness = 0.0
+
 [node name="Demo" type="Node3D"]
 script = ExtResource("1_ss3lw")
 
@@ -30,10 +37,12 @@ shadow_enabled = true
 [node name="WorldEnvironment" type="WorldEnvironment" parent="Env"]
 environment = SubResource("Environment_ss3lw")
 
-[node name="Floor" type="CSGBox3D" parent="."]
-transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, -0.05, 0)
+[node name="CSGBox3D" type="CSGBox3D" parent="."]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0.200953, 5.03202, -0.16352)
+material_override = SubResource("StandardMaterial3D_woynx")
 use_collision = true
-size = Vector3(10, 0.1, 10)
+flip_faces = true
+size = Vector3(30, 10, 30)
 
 [node name="Player" parent="." instance=ExtResource("1_vyiun")]
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -0.629, 1, 0.01)

--- a/third-person-controllers/third-person-controller/state-machine/dash.gd
+++ b/third-person-controllers/third-person-controller/state-machine/dash.gd
@@ -1,0 +1,22 @@
+extends ThirdPersonControllerState
+
+@onready var duration: Timer = $Duration
+@onready var cooldown: Timer = $Cooldown
+
+func _enter(_p, _d = {}) -> void:
+	tpc._do_dash()
+	duration.start(tpc.dash_length / tpc.dash_speed)
+	tpc.is_dash_ready = false
+
+func _exit() -> void:
+	cooldown.start(tpc.dash_cooldown)
+
+func _do_physics_process(_d) -> void:
+	tpc.move_and_slide()
+
+func _on_duration_timeout() -> void:
+	finished.emit(IWR)
+
+
+func _on_cooldown_timeout() -> void:
+	tpc.is_dash_ready = true

--- a/third-person-controllers/third-person-controller/state-machine/dash.gd
+++ b/third-person-controllers/third-person-controller/state-machine/dash.gd
@@ -4,14 +4,18 @@ extends ThirdPersonControllerState
 @onready var cooldown: Timer = $Cooldown
 
 func _enter(_p, _d = {}) -> void:
+	# print("Dash _enter")
 	tpc._do_dash()
 	duration.start(tpc.dash_length / tpc.dash_speed)
 	tpc.is_dash_ready = false
+	super (_p, _d)
 
 func _exit() -> void:
+	# print("Dash _exit")
 	cooldown.start(tpc.dash_cooldown)
 
 func _do_physics_process(_d) -> void:
+	# print("Dash _do_physics_process")
 	tpc.move_and_slide()
 
 func _on_duration_timeout() -> void:

--- a/third-person-controllers/third-person-controller/state-machine/dash.gd
+++ b/third-person-controllers/third-person-controller/state-machine/dash.gd
@@ -17,6 +17,5 @@ func _do_physics_process(_d) -> void:
 func _on_duration_timeout() -> void:
 	finished.emit(IWR)
 
-
 func _on_cooldown_timeout() -> void:
 	tpc.is_dash_ready = true

--- a/third-person-controllers/third-person-controller/state-machine/dash.gd.uid
+++ b/third-person-controllers/third-person-controller/state-machine/dash.gd.uid
@@ -1,0 +1,1 @@
+uid://dnyuk46th8ggg

--- a/third-person-controllers/third-person-controller/state-machine/fall.gd
+++ b/third-person-controllers/third-person-controller/state-machine/fall.gd
@@ -1,13 +1,10 @@
 extends ThirdPersonControllerState
 
-func _enter(_p, _d = {}) -> void:
-	pass
-
-func _exit() -> void:
-	pass
-
 func _do_physics_process(delta: float) -> void:
-	if tpc.is_on_floor():
+	if tpc.is_start_dash():
+		finished.emit(DASH)
+		return
+	elif tpc.is_on_floor():
 		finished.emit(IWR)
 		return
 	

--- a/third-person-controllers/third-person-controller/state-machine/fall.gd
+++ b/third-person-controllers/third-person-controller/state-machine/fall.gd
@@ -1,11 +1,18 @@
 extends ThirdPersonControllerState
 
 func _do_physics_process(delta: float) -> void:
+	# print("Fall _do_physics_process")
 	if tpc.is_start_dash():
-		finished.emit(DASH)
+		finished.emit(DASH, {
+			"delta": delta,
+			"func": "_do_physics_process"
+		})
 		return
 	elif tpc.is_on_floor():
-		finished.emit(IWR)
+		finished.emit(IWR, {
+			"delta": delta,
+			"func": "_do_physics_process"
+		})
 		return
 	
 	tpc._do_fall(delta)

--- a/third-person-controllers/third-person-controller/state-machine/idle_walk_run.gd
+++ b/third-person-controllers/third-person-controller/state-machine/idle_walk_run.gd
@@ -1,14 +1,24 @@
 extends ThirdPersonControllerState
 
 func _do_physics_process(delta: float) -> void:
+	# print("IWR _do_physics_process")
 	if tpc.is_start_dash():
-		finished.emit(DASH)
+		finished.emit(DASH, {
+			"delta": delta,
+			"func": "_do_physics_process"
+		})
 		return
 	elif not tpc.is_on_floor():
-		finished.emit(FALL)
+		finished.emit(FALL, {
+			"delta": delta,
+			"func": "_do_physics_process"
+		})
 		return
 	elif Input.is_action_pressed("jump"):
-		finished.emit(JUMP)
+		finished.emit(JUMP, {
+			"delta": delta,
+			"func": "_do_physics_process"
+		})
 		return
 
 	tpc._do_iwr(delta)

--- a/third-person-controllers/third-person-controller/state-machine/idle_walk_run.gd
+++ b/third-person-controllers/third-person-controller/state-machine/idle_walk_run.gd
@@ -1,16 +1,13 @@
 extends ThirdPersonControllerState
 
-func _enter(_p, _d = {}) -> void:
-	pass
-
-func _exit() -> void:
-	pass
-
 func _do_physics_process(delta: float) -> void:
-	if not tpc.is_on_floor():
+	if tpc.is_start_dash():
+		finished.emit(DASH)
+		return
+	elif not tpc.is_on_floor():
 		finished.emit(FALL)
 		return
-	elif Input.is_action_just_pressed("jump"):
+	elif Input.is_action_pressed("jump"):
 		finished.emit(JUMP)
 		return
 

--- a/third-person-controllers/third-person-controller/state-machine/jump.gd
+++ b/third-person-controllers/third-person-controller/state-machine/jump.gd
@@ -1,6 +1,10 @@
 extends ThirdPersonControllerState
 
-func _do_physics_process(_d) -> void:
+func _do_physics_process(d) -> void:
+	# print("Jump _do_physics_process")
 	tpc.velocity.y = tpc.jump_velocity
 	tpc.move_and_slide()
-	finished.emit(FALL)
+	finished.emit(FALL, {
+		"delta": d,
+		"func": "_do_physics_process"
+	})

--- a/third-person-controllers/third-person-controller/state-machine/jump.gd
+++ b/third-person-controllers/third-person-controller/state-machine/jump.gd
@@ -1,11 +1,5 @@
 extends ThirdPersonControllerState
 
-func _enter(_p, _d = {}) -> void:
-	pass
-
-func _exit() -> void:
-	pass
-
 func _do_physics_process(_d) -> void:
 	tpc.velocity.y = tpc.jump_velocity
 	tpc.move_and_slide()

--- a/third-person-controllers/third-person-controller/state-machine/state.gd
+++ b/third-person-controllers/third-person-controller/state-machine/state.gd
@@ -9,4 +9,4 @@ var tpc: ThirdPersonController
 func _ready() -> void:
 	await owner.ready
 	tpc = owner as ThirdPersonController
-	assert(tpc != null, "The ThirdPersonControllerState type must be a direct child of a ThirdPersonController.")
+	assert(tpc != null, "ThirdPersonControllerState must be a child of ThirdPersonController.")

--- a/third-person-controllers/third-person-controller/state-machine/state.gd
+++ b/third-person-controllers/third-person-controller/state-machine/state.gd
@@ -3,6 +3,7 @@ class_name ThirdPersonControllerState extends State
 const IWR := "IdleWalkRun"
 const JUMP := "Jump"
 const FALL := "Fall"
+const DASH := "Dash"
 
 var tpc: ThirdPersonController
 

--- a/third-person-controllers/third-person-controller/third-person-controller.tscn
+++ b/third-person-controllers/third-person-controller/third-person-controller.tscn
@@ -53,6 +53,7 @@ shape = SubResource("CapsuleShape3D_ss2ul")
 
 [node name="Twist" type="Node3D" parent="."]
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0.5, 0)
+top_level = true
 script = ExtResource("2_i6k8c")
 
 [node name="Pitch" type="Node3D" parent="Twist"]

--- a/third-person-controllers/third-person-controller/third-person-controller.tscn
+++ b/third-person-controllers/third-person-controller/third-person-controller.tscn
@@ -1,7 +1,8 @@
-[gd_scene load_steps=14 format=3 uid="uid://oxyumaw1iadk"]
+[gd_scene load_steps=15 format=3 uid="uid://oxyumaw1iadk"]
 
 [ext_resource type="Script" uid="uid://d0ixx1sbbgv3y" path="res://third-person-controller/third_person_controller.gd" id="1_raonk"]
 [ext_resource type="Script" uid="uid://drcjvbdv55mrc" path="res://third-person-controller/state-machine/state_machine.gd" id="2_hq6i3"]
+[ext_resource type="Script" uid="uid://crr8qcwlunyou" path="res://third-person-controller/twist.gd" id="2_i6k8c"]
 [ext_resource type="Script" uid="uid://d2tx5e4nqly0v" path="res://third-person-controller/state-machine/idle_walk_run.gd" id="3_otdli"]
 [ext_resource type="Script" uid="uid://dq5nuw1p8r2m5" path="res://third-person-controller/state-machine/jump.gd" id="4_i6k8c"]
 [ext_resource type="Script" uid="uid://d3bo8vc5ho77h" path="res://third-person-controller/state-machine/fall.gd" id="5_otdli"]
@@ -52,11 +53,12 @@ shape = SubResource("CapsuleShape3D_ss2ul")
 
 [node name="Twist" type="Node3D" parent="."]
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0.5, 0)
+script = ExtResource("2_i6k8c")
 
 [node name="Pitch" type="Node3D" parent="Twist"]
 transform = Transform3D(1, 0, 0, 0, 0.965926, 0.258819, 0, -0.258819, 0.965926, 0, 0, 0)
 
-[node name="Camera3D" type="Camera3D" parent="Twist/Pitch"]
+[node name="FreeCamera" type="Camera3D" parent="Twist/Pitch"]
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0.2, 1, 5)
 
 [node name="StateMachine" type="Node" parent="." node_paths=PackedStringArray("initial_state")]

--- a/third-person-controllers/third-person-controller/third-person-controller.tscn
+++ b/third-person-controllers/third-person-controller/third-person-controller.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=15 format=3 uid="uid://oxyumaw1iadk"]
+[gd_scene load_steps=16 format=3 uid="uid://oxyumaw1iadk"]
 
 [ext_resource type="Script" uid="uid://d0ixx1sbbgv3y" path="res://third-person-controller/third_person_controller.gd" id="1_raonk"]
 [ext_resource type="Script" uid="uid://drcjvbdv55mrc" path="res://third-person-controller/state-machine/state_machine.gd" id="2_hq6i3"]
@@ -6,6 +6,7 @@
 [ext_resource type="Script" uid="uid://d2tx5e4nqly0v" path="res://third-person-controller/state-machine/idle_walk_run.gd" id="3_otdli"]
 [ext_resource type="Script" uid="uid://dq5nuw1p8r2m5" path="res://third-person-controller/state-machine/jump.gd" id="4_i6k8c"]
 [ext_resource type="Script" uid="uid://d3bo8vc5ho77h" path="res://third-person-controller/state-machine/fall.gd" id="5_otdli"]
+[ext_resource type="Script" uid="uid://dnyuk46th8ggg" path="res://third-person-controller/state-machine/dash.gd" id="7_yid2g"]
 
 [sub_resource type="Gradient" id="Gradient_fm20d"]
 colors = PackedColorArray(0, 0.623711, 0.62869, 1, 1, 1, 1, 1)
@@ -74,3 +75,15 @@ script = ExtResource("4_i6k8c")
 
 [node name="Fall" type="Node" parent="StateMachine"]
 script = ExtResource("5_otdli")
+
+[node name="Dash" type="Node" parent="StateMachine"]
+script = ExtResource("7_yid2g")
+
+[node name="Duration" type="Timer" parent="StateMachine/Dash"]
+one_shot = true
+
+[node name="Cooldown" type="Timer" parent="StateMachine/Dash"]
+
+[connection signal="last_movement_direction_updated" from="." to="Twist" method="_on_player_last_movement_direction_updated"]
+[connection signal="timeout" from="StateMachine/Dash/Duration" to="StateMachine/Dash" method="_on_duration_timeout"]
+[connection signal="timeout" from="StateMachine/Dash/Cooldown" to="StateMachine/Dash" method="_on_cooldown_timeout"]

--- a/third-person-controllers/third-person-controller/third_person_controller.gd
+++ b/third-person-controllers/third-person-controller/third_person_controller.gd
@@ -1,5 +1,7 @@
 class_name ThirdPersonController extends CharacterBody3D
 
+signal last_movement_direction_updated(direction: Vector3)
+
 @onready var model: Node3D = $Model
 @onready var twist_pivot: Node3D = $Twist
 
@@ -29,6 +31,7 @@ func _do_iwr(delta: float) -> void:
 		_last_movement_direction = Vector3(input_direction.x, 0, input_direction.y).rotated(Vector3.UP, twist_pivot.rotation.y) * input_magnitude * speed
 		velocity.x = _last_movement_direction.x
 		velocity.z = _last_movement_direction.z
+		last_movement_direction_updated.emit(_last_movement_direction)
 		
 	var target_angle := Vector3.FORWARD.signed_angle_to(_last_movement_direction, Vector3.UP)
 	model.rotation.y = lerp_angle(model.rotation.y, target_angle, rotation_speed * delta)

--- a/third-person-controllers/third-person-controller/third_person_controller.gd
+++ b/third-person-controllers/third-person-controller/third_person_controller.gd
@@ -2,14 +2,6 @@ class_name ThirdPersonController extends CharacterBody3D
 
 @onready var model: Node3D = $Model
 @onready var twist_pivot: Node3D = $Twist
-@onready var pitch_pivot: Node3D = $Twist/Pitch
-
-func _unhandled_input(event: InputEvent) -> void:
-	_capture_unhandled_mouse_event(event)
-
-func _process(delta: float) -> void:
-	_camera_rotate_twist(delta)
-	_camera_rotate_pitch(delta)
 
 @export_category("Movement Options")
 @export var speed := 5.0
@@ -40,74 +32,6 @@ func _do_iwr(delta: float) -> void:
 		
 	var target_angle := Vector3.FORWARD.signed_angle_to(_last_movement_direction, Vector3.UP)
 	model.rotation.y = lerp_angle(model.rotation.y, target_angle, rotation_speed * delta)
-	
 
 func _do_fall(delta: float) -> void:
 	velocity += get_gravity() * delta
-	
-@export_category("Camera Options")
-@export var camera_init_twist := 0.0
-@export var camera_init_pitch := 0.0
-@export var camera_init_dist := 10.0
-@export var camera_lock_twist := false
-@export var camera_lock_pitch := false
-@export var camera_lock_dist := true
-@export var camera_mouse_sensitivity := 0.001
-@export var camera_pitch_min := -30.0
-@export var camera_pitch_max := 30.0
-@export var camera_dist_min := 3.0
-@export var camera_dist_max := 10.0
-@export var look_invert_x := true
-@export var look_invert_y := false
-
-func _get_camera_look_vector() -> Vector2:
-	var look_vector := Input.get_vector("look_left", "look_right", "look_down", "look_up")
-	if look_vector.length() > 1:
-		return look_vector.normalized()
-
-	return look_vector
-
-var twist_input_mouse := 0.0
-func _camera_rotate_twist(delta: float) -> void:
-	if not camera_lock_twist:
-		var twist_input := _get_camera_look_vector().x * delta
-		if twist_input == 0:
-			twist_input = twist_input_mouse
-		
-		if look_invert_x:
-			twist_input *= -1
-
-		twist_pivot.rotate_y(twist_input)
-
-	twist_input_mouse = 0.0
-
-var pitch_input_mouse := 0.0
-func _camera_rotate_pitch(delta: float) -> void:
-	if not camera_lock_pitch:
-		var pitch_input := _get_camera_look_vector().y * delta
-		if pitch_input == 0:
-			pitch_input = pitch_input_mouse
-
-		if look_invert_y:
-			pitch_input *= -1
-
-		pitch_pivot.rotate_x(pitch_input)
-
-	pitch_input_mouse = 0.0
-	pitch_pivot.rotation.x = clamp(
-		pitch_pivot.rotation.x,
-		deg_to_rad(camera_pitch_min),
-		deg_to_rad(camera_pitch_max)
-	)
-
-var mouse_input_clamp := 1.0
-func _mouse_clamp(value: float, size: float) -> float:
-	return clampf(value, -size, size)
-
-func _capture_unhandled_mouse_event(event: InputEvent) -> void:
-	if Input.get_mouse_mode() != Input.MOUSE_MODE_CAPTURED:
-			return
-
-	if event is InputEventMouseMotion:
-		twist_input_mouse = _mouse_clamp(event.relative.x * camera_mouse_sensitivity, mouse_input_clamp)
-		pitch_input_mouse = _mouse_clamp(event.relative.y * camera_mouse_sensitivity, mouse_input_clamp)

--- a/third-person-controllers/third-person-controller/third_person_controller.gd
+++ b/third-person-controllers/third-person-controller/third_person_controller.gd
@@ -9,15 +9,41 @@ signal last_movement_direction_updated(direction: Vector3)
 @export var speed := 5.0
 @export var rotation_speed := 12.0
 @export var jump_velocity := 4.5
-# These will be added in later PRs
-# @export var dash_speed := 10.0
-# @export var dash_length := 5.0
-# @export var dash_cooldown := 0.2
-# var dash_direction: Vector3
-# var dash_length_remaining := 0.0
-# var dash_cooldown_timer := 0.0
+@export var dash_speed := 10.0
+@export var dash_length := 5.0
+@export var dash_cooldown := 0.3
+@export var is_dash_hold := false
 
+var is_dash_ready := true
 var _last_movement_direction := Vector3.FORWARD
+
+func is_start_dash() -> bool: return (
+	is_dash_ready and
+	(
+		Input.is_action_just_pressed("dash") or
+		(
+			is_dash_hold and
+			Input.is_action_pressed("dash")
+		)
+	)
+)
+
+func _set_last_movement_direction(direction: Vector3) -> void:
+	_last_movement_direction = direction
+	last_movement_direction_updated.emit(direction)
+
+func _do_dash() -> void:
+	var input_vector := Input.get_vector("move_left", "move_right", "move_up", "move_down")
+	var dash_direction := (
+		Vector3(input_vector.x, 0, input_vector.y).rotated(Vector3.UP, twist_pivot.rotation.y) if input_vector else
+		Vector3.FORWARD.rotated(Vector3.UP, model.rotation.y)
+	).normalized()
+	
+	var direction = dash_direction * dash_speed
+	velocity.x = direction.x
+	velocity.z = direction.z
+	velocity.y = 0
+	_set_last_movement_direction(dash_direction)
 
 func _do_iwr(delta: float) -> void:
 	var input_vector := Input.get_vector("move_left", "move_right", "move_up", "move_down")

--- a/third-person-controllers/third-person-controller/twist.gd
+++ b/third-person-controllers/third-person-controller/twist.gd
@@ -6,7 +6,6 @@ func _ready() -> void:
 	await owner.ready
 	tpc = owner as ThirdPersonController
 	assert(tpc != null, "ThirdPersonController_Twist must be a child of ThirdPersonController.")
-	tpc.last_movement_direction_updated.connect(_handle_last_movement_direction_updated)
 
 func _unhandled_input(event: InputEvent) -> void:
 	_capture_unhandled_mouse_event(event)
@@ -38,7 +37,7 @@ var mouse_input_clamp := 1.0
 var last_camera_lag := 0.0
 var _last_movement_direction := Vector3.FORWARD
 
-func _handle_last_movement_direction_updated(direction: Vector3) -> void:
+func _on_player_last_movement_direction_updated(direction: Vector3) -> void:
 	_last_movement_direction = direction
 
 func _get_camera_look_vector() -> Vector2:

--- a/third-person-controllers/third-person-controller/twist.gd
+++ b/third-person-controllers/third-person-controller/twist.gd
@@ -1,0 +1,74 @@
+class_name ThirdPersonController_Twist extends Node3D
+
+func _unhandled_input(event: InputEvent) -> void:
+	_capture_unhandled_mouse_event(event)
+
+func _process(delta: float) -> void:
+	_camera_rotate_twist(delta)
+	_camera_rotate_pitch(delta)
+
+@onready var pitch_pivot: Node3D = $Pitch
+
+@export_category("Camera Options")
+@export var camera_init_twist := 0.0
+@export var camera_init_pitch := 0.0
+@export var camera_lock_twist := false
+@export var camera_lock_pitch := false
+@export var camera_mouse_sensitivity := 0.001
+@export var camera_pitch_min := -30.0
+@export var camera_pitch_max := 30.0
+@export var look_invert_x := true
+@export var look_invert_y := false
+
+var twist_input_mouse := 0.0
+var pitch_input_mouse := 0.0
+var mouse_input_clamp := 1.0
+
+func _get_camera_look_vector() -> Vector2:
+	var look_vector := Input.get_vector("look_left", "look_right", "look_down", "look_up")
+	if look_vector.length() > 1:
+		return look_vector.normalized()
+
+	return look_vector
+
+
+func _camera_rotate_twist(delta: float) -> void:
+	if not camera_lock_twist:
+		var twist_input := _get_camera_look_vector().x * delta
+		if twist_input == 0:
+			twist_input = twist_input_mouse
+		
+		if look_invert_x:
+			twist_input *= -1
+
+		rotate_y(twist_input)
+
+	twist_input_mouse = 0.0
+
+func _camera_rotate_pitch(delta: float) -> void:
+	if not camera_lock_pitch:
+		var pitch_input := _get_camera_look_vector().y * delta
+		if pitch_input == 0:
+			pitch_input = pitch_input_mouse
+
+		if look_invert_y:
+			pitch_input *= -1
+
+		pitch_pivot.rotate_x(pitch_input)
+
+	pitch_input_mouse = 0.0
+	pitch_pivot.rotation.x = clamp(
+		pitch_pivot.rotation.x,
+		deg_to_rad(camera_pitch_min),
+		deg_to_rad(camera_pitch_max)
+	)
+
+func _mouse_clamp(value: float, size: float) -> float: return clampf(value, -size, size)
+
+func _capture_unhandled_mouse_event(event: InputEvent) -> void:
+	if Input.get_mouse_mode() != Input.MOUSE_MODE_CAPTURED:
+			return
+
+	if event is InputEventMouseMotion:
+		twist_input_mouse = _mouse_clamp(event.relative.x * camera_mouse_sensitivity, mouse_input_clamp)
+		pitch_input_mouse = _mouse_clamp(event.relative.y * camera_mouse_sensitivity, mouse_input_clamp)

--- a/third-person-controllers/third-person-controller/twist.gd
+++ b/third-person-controllers/third-person-controller/twist.gd
@@ -1,11 +1,22 @@
 class_name ThirdPersonController_Twist extends Node3D
 
+var tpc: ThirdPersonController
+
+func _ready() -> void:
+	await owner.ready
+	tpc = owner as ThirdPersonController
+	assert(tpc != null, "ThirdPersonController_Twist must be a child of ThirdPersonController.")
+	tpc.last_movement_direction_updated.connect(_handle_last_movement_direction_updated)
+
 func _unhandled_input(event: InputEvent) -> void:
 	_capture_unhandled_mouse_event(event)
 
 func _process(delta: float) -> void:
 	_camera_rotate_twist(delta)
 	_camera_rotate_pitch(delta)
+
+func _physics_process(delta: float) -> void:
+	_follow_player(delta)
 
 @onready var pitch_pivot: Node3D = $Pitch
 
@@ -23,6 +34,12 @@ func _process(delta: float) -> void:
 var twist_input_mouse := 0.0
 var pitch_input_mouse := 0.0
 var mouse_input_clamp := 1.0
+
+var last_camera_lag := 0.0
+var _last_movement_direction := Vector3.FORWARD
+
+func _handle_last_movement_direction_updated(direction: Vector3) -> void:
+	_last_movement_direction = direction
 
 func _get_camera_look_vector() -> Vector2:
 	var look_vector := Input.get_vector("look_left", "look_right", "look_down", "look_up")
@@ -72,3 +89,7 @@ func _capture_unhandled_mouse_event(event: InputEvent) -> void:
 	if event is InputEventMouseMotion:
 		twist_input_mouse = _mouse_clamp(event.relative.x * camera_mouse_sensitivity, mouse_input_clamp)
 		pitch_input_mouse = _mouse_clamp(event.relative.y * camera_mouse_sensitivity, mouse_input_clamp)
+
+func _follow_player(_delta: float) -> void:
+	last_camera_lag = 0.15
+	position = lerp(position, tpc.position, last_camera_lag)

--- a/third-person-controllers/third-person-controller/twist.gd.uid
+++ b/third-person-controllers/third-person-controller/twist.gd.uid
@@ -1,0 +1,1 @@
+uid://crr8qcwlunyou


### PR DESCRIPTION
Add dash mechanic to player in third-person controller.

Bindings:
- Keyboard: Shift (any)
- Controller: L1/Left Bumper

Player can dash from IWR and Falling state
Dash will transition to IWR when complete

Moved camera controller code to the $Player/Twist node
$Player/Twist set to root level
$Player/Twist follows player with slight delay, dashing increases delay

Update State machine, base state class supports immediately executing processing functions.