### PR TITLE
fix: Use screen_relative for aim-related actions

### DIFF
--- a/third-person-controllers/third-person-controller/third-person-controller.tscn
+++ b/third-person-controllers/third-person-controller/third-person-controller.tscn
@@ -56,7 +56,7 @@ shape = SubResource("CapsuleShape3D_ss2ul")
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0.5, 0)
 top_level = true
 script = ExtResource("2_i6k8c")
-look_invert_x = false
+look_invert_y = true
 
 [node name="Pitch" type="Node3D" parent="Twist"]
 transform = Transform3D(1, 0, 0, 0, 0.965926, 0.258819, 0, -0.258819, 0.965926, 0, 0, 0)

--- a/third-person-controllers/third-person-controller/twist.gd
+++ b/third-person-controllers/third-person-controller/twist.gd
@@ -86,8 +86,8 @@ func _capture_unhandled_mouse_event(event: InputEvent) -> void:
 			return
 
 	if event is InputEventMouseMotion:
-		twist_input_mouse = _mouse_clamp(event.relative.x * camera_mouse_sensitivity, mouse_input_clamp)
-		pitch_input_mouse = _mouse_clamp(event.relative.y * camera_mouse_sensitivity, mouse_input_clamp)
+		twist_input_mouse = _mouse_clamp(event.screen_relative.x * camera_mouse_sensitivity, mouse_input_clamp)
+		pitch_input_mouse = _mouse_clamp(event.screen_relative.y * camera_mouse_sensitivity, mouse_input_clamp)
 
 func _follow_player(_delta: float) -> void:
 	last_camera_lag = 0.15


### PR DESCRIPTION
From Godot docs:
> Note: This coordinate is not scaled according to the content scale factor or calls to InputEvent.xformed_by. This should be preferred over relative for mouse aiming when using the Input.MOUSE_MODE_CAPTURED mouse mode, regardless of the project's stretch mode.