### PR TITLE
fix: look towards dash direction

### DIFF
--- a/third-person-controllers/third-person-controller/state-machine/dash.gd
+++ b/third-person-controllers/third-person-controller/state-machine/dash.gd
@@ -8,6 +8,7 @@ func _enter(_p, _d = {}) -> void:
 	tpc._do_dash()
 	duration.start(tpc.dash_length / tpc.dash_speed)
 	tpc.is_dash_ready = false
+	tpc.look_forward(1.0)
 	super (_p, _d)
 
 func _exit() -> void:

--- a/third-person-controllers/third-person-controller/third_person_controller.gd
+++ b/third-person-controllers/third-person-controller/third_person_controller.gd
@@ -29,9 +29,14 @@ func is_start_dash() -> bool: return (
 	)
 )
 
-func _set_last_movement_direction(direction: Vector3) -> void:
+func get_last_movement_direction() -> Vector3: return _last_movement_direction
+func set_last_movement_direction(direction: Vector3) -> void:
 	_last_movement_direction = direction
 	last_movement_direction_updated.emit(direction)
+
+func look_forward(weight: float) -> void:
+	var target_angle := Vector3.FORWARD.signed_angle_to(_last_movement_direction, Vector3.UP)
+	model.rotation.y = lerp_angle(model.rotation.y, target_angle, weight)
 
 func _do_dash() -> void:
 	var input_vector := Input.get_vector("move_left", "move_right", "move_up", "move_down")
@@ -44,7 +49,7 @@ func _do_dash() -> void:
 	velocity.x = direction.x
 	velocity.z = direction.z
 	velocity.y = 0
-	_set_last_movement_direction(dash_direction)
+	set_last_movement_direction(dash_direction)
 
 func _do_iwr(delta: float) -> void:
 	var input_vector := Input.get_vector("move_left", "move_right", "move_up", "move_down")
@@ -55,13 +60,11 @@ func _do_iwr(delta: float) -> void:
 		velocity.x = move_toward(velocity.x, 0, speed)
 		velocity.z = move_toward(velocity.z, 0, speed)
 	else:
-		_last_movement_direction = Vector3(input_direction.x, 0, input_direction.y).rotated(Vector3.UP, twist_pivot.rotation.y) * input_magnitude * speed
+		set_last_movement_direction(Vector3(input_direction.x, 0, input_direction.y).rotated(Vector3.UP, twist_pivot.rotation.y) * input_magnitude * speed)
 		velocity.x = _last_movement_direction.x
 		velocity.z = _last_movement_direction.z
-		last_movement_direction_updated.emit(_last_movement_direction)
 		
-	var target_angle := Vector3.FORWARD.signed_angle_to(_last_movement_direction, Vector3.UP)
-	model.rotation.y = lerp_angle(model.rotation.y, target_angle, rotation_speed * delta)
+	look_forward(rotation_speed * delta)
 
 func _do_fall(delta: float) -> void:
 	velocity += get_gravity() * delta


### PR DESCRIPTION
> Generated by Gemini 2.0 Flash

## fix-dash-look-direction

Fix: Character now looks towards dash direction.

The changes modify the dash state and the third-person controller to ensure the character model rotates to face the direction of the dash.  This involves updating the last movement direction and applying a rotation to the model.

### Changes
- Added `look_forward(weight: float)` function to `third_person_controller.gd` to handle model rotation based on `_last_movement_direction`.
- Modified `dash.gd` to call `tpc.look_forward(1.0)` on state entry, ensuring the character immediately faces the dash direction.
- Replaced direct assignment to `_last_movement_direction` with calls to `set_last_movement_direction(direction: Vector3)` to use the setter function.
- Added `get_last_movement_direction()` to allow access to the `_last_movement_direction` variable.
- Refactored `_do_iwr` function to use `look_forward` instead of directly setting model rotation.

### Impact
- The character model now correctly faces the dash direction upon initiating a dash.
- The `look_forward` function consolidates the logic for character rotation, making it reusable.
- The changes improve the visual fidelity of the dash action.