### PR TITLE
fix: dash slide

### DIFF
--- a/third-person-controllers/third-person-controller/state-machine/dash.gd
+++ b/third-person-controllers/third-person-controller/state-machine/dash.gd
@@ -14,6 +14,7 @@ func _enter(_p, _d = {}) -> void:
 func _exit() -> void:
 	# print("Dash _exit")
 	cooldown.start(tpc.dash_cooldown)
+	tpc._end_dash()
 
 func _do_physics_process(_d) -> void:
 	# print("Dash _do_physics_process")

--- a/third-person-controllers/third-person-controller/third_person_controller.gd
+++ b/third-person-controllers/third-person-controller/third_person_controller.gd
@@ -17,6 +17,7 @@ signal last_movement_direction_updated(direction: Vector3)
 
 var is_dash_ready := true
 var _last_movement_direction := Vector3.FORWARD
+var _look_direction := Vector3.FORWARD
 
 func is_start_dash() -> bool: return (
 	is_dash_ready and
@@ -32,10 +33,11 @@ func is_start_dash() -> bool: return (
 func get_last_movement_direction() -> Vector3: return _last_movement_direction
 func set_last_movement_direction(direction: Vector3) -> void:
 	_last_movement_direction = direction
+	_look_direction = direction
 	last_movement_direction_updated.emit(direction)
 
 func look_forward(weight: float) -> void:
-	var target_angle := Vector3.FORWARD.signed_angle_to(_last_movement_direction, Vector3.UP)
+	var target_angle := Vector3.FORWARD.signed_angle_to(_look_direction, Vector3.UP)
 	model.rotation.y = lerp_angle(model.rotation.y, target_angle, weight)
 
 func _do_dash() -> void:
@@ -50,6 +52,10 @@ func _do_dash() -> void:
 	velocity.z = direction.z
 	velocity.y = 0
 	set_last_movement_direction(dash_direction)
+
+func _end_dash() -> void:
+	velocity.x = move_toward(velocity.x, speed, dash_speed)
+	velocity.z = move_toward(velocity.z, speed, dash_speed)
 
 func _do_iwr(delta: float) -> void:
 	var input_vector := Input.get_vector("move_left", "move_right", "move_up", "move_down")


### PR DESCRIPTION
# Branch Summary

> Generated by Gemini 2.0 Flash

## fix-dash-slide

Fix dash slide issue.

The changes address an issue where the character would continue sliding after a dash. This is achieved by introducing a function to halt the dash velocity.

### Changes
- Introduced `_end_dash()` function in `third_person_controller.gd` to gradually reduce velocity after a dash. This function is called upon exiting the dash state.
- Added a new member variable `_look_direction` in `third_person_controller.gd` which mirrors `_last_movement_direction`. The `look_forward` function now uses `_look_direction` instead of `_last_movement_direction` for calculating the target angle.
- Modified `set_last_movement_direction` in `third_person_controller.gd` to also set the `_look_direction`.
- Modified `dash.gd` to call the `_end_dash` function on exiting the dash state.

### Impact
- Resolves the unwanted sliding behavior after a dash.
- The `look_forward` function now relies on the `_look_direction` which is updated when the `last_movement_direction` changes. This ensures the model faces the correct direction.
- No breaking changes are apparent.
- Performance implications are negligible.