### PR TITLE
fix: Move player to collision layer 2 to fix dash collision issue

### DIFF
--- a/third-person-controllers/third-person-controller/demo.tscn
+++ b/third-person-controllers/third-person-controller/demo.tscn
@@ -43,7 +43,7 @@ transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0.200953, 5.03202, -0.16352)
 material_override = SubResource("StandardMaterial3D_woynx")
 use_collision = true
 flip_faces = true
-size = Vector3(30, 10, 30)
+size = Vector3(50, 50, 50)
 
 [node name="Player" parent="." instance=ExtResource("1_vyiun")]
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -0.629, 1, 0.01)

--- a/third-person-controllers/third-person-controller/third-person-controller.tscn
+++ b/third-person-controllers/third-person-controller/third-person-controller.tscn
@@ -38,6 +38,7 @@ height = 0.95
 [sub_resource type="SeparationRayShape3D" id="SeparationRayShape3D_yid2g"]
 
 [node name="Player" type="CharacterBody3D"]
+collision_layer = 2
 script = ExtResource("1_raonk")
 
 [node name="Model" type="Node3D" parent="."]


### PR DESCRIPTION
# Branch Summary

> Generated by Gemini 2.0 Flash

## fix-dash-towards-camera

Fix dash collision: Move player to collision layer 2.

The change moves the player object to collision layer 2 in the demo scene. This resolves a collision issue experienced during player's dash.

### Changes
- Changed the collision layer of the Player node to 2 in `third-person-controllers/third-person-controller/third-person-controller.tscn`.
- Increased the size of the StaticBody3D in `third-person-controllers/third-person-controller/demo.tscn` from `Vector3(30, 10, 30)` to `Vector3(50, 50, 50)`.

### Impact
- Fixes a reported collision issue during the dash action, likely preventing the player from passing through certain colliders.
- The increased size of the StaticBody3D might affect the play area or how the player interacts with the environment, possibly requiring adjustments to level design or player movement parameters.