### PR TITLE
refactor: Cleanup and refactor last movement direction

### DIFF
--- a/third-person-controllers/third-person-controller/third-person-controller.tscn
+++ b/third-person-controllers/third-person-controller/third-person-controller.tscn
@@ -95,6 +95,5 @@ one_shot = true
 [node name="HealthBar3d" parent="." instance=ExtResource("8_mditm")]
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 1.29492, 0)
 
-[connection signal="last_movement_direction_updated" from="." to="Twist" method="_on_player_last_movement_direction_updated"]
 [connection signal="timeout" from="StateMachine/Dash/Duration" to="StateMachine/Dash" method="_on_duration_timeout"]
 [connection signal="timeout" from="StateMachine/Dash/Cooldown" to="StateMachine/Dash" method="_on_cooldown_timeout"]

--- a/third-person-controllers/third-person-controller/third_person_controller.gd
+++ b/third-person-controllers/third-person-controller/third_person_controller.gd
@@ -1,7 +1,5 @@
 class_name ThirdPersonController extends CharacterBody3D
 
-signal last_movement_direction_updated(direction: Vector3)
-
 func _ready() -> void:
 	twist_pivot.top_level = true
 	$HealthBar3d.set_max_value(max_hp)
@@ -33,7 +31,10 @@ func _ready() -> void:
 @export var is_mid_air_movement := true
 
 var is_dash_ready := true
-var _last_movement_direction := Vector3.FORWARD
+var last_movement_direction := Vector3.FORWARD:
+	set(v):
+		last_movement_direction = v
+		_look_direction = v
 var _look_direction := Vector3.FORWARD
 
 func is_start_dash() -> bool: return (
@@ -46,12 +47,6 @@ func is_start_dash() -> bool: return (
 		)
 	)
 )
-
-func get_last_movement_direction() -> Vector3: return _last_movement_direction
-func set_last_movement_direction(direction: Vector3) -> void:
-	_last_movement_direction = direction
-	_look_direction = direction
-	last_movement_direction_updated.emit(direction)
 
 func look_forward(weight: float) -> void:
 	var target_angle := Vector3.FORWARD.signed_angle_to(_look_direction, Vector3.UP)
@@ -68,7 +63,7 @@ func _do_dash() -> void:
 	velocity.x = direction.x
 	velocity.z = direction.z
 	velocity.y = 0
-	set_last_movement_direction(dash_direction)
+	last_movement_direction = dash_direction
 
 func _end_dash() -> void:
 	velocity.x = move_toward(velocity.x, speed, dash_speed)
@@ -83,9 +78,9 @@ func _do_iwr(delta: float) -> void:
 		velocity.x = move_toward(velocity.x, 0, speed)
 		velocity.z = move_toward(velocity.z, 0, speed)
 	else:
-		set_last_movement_direction(Vector3(input_direction.x, 0, input_direction.y).rotated(Vector3.UP, twist_pivot.rotation.y) * input_magnitude * speed)
-		velocity.x = _last_movement_direction.x
-		velocity.z = _last_movement_direction.z
+		last_movement_direction = Vector3(input_direction.x, 0, input_direction.y).rotated(Vector3.UP, twist_pivot.rotation.y) * input_magnitude * speed
+		velocity.x = last_movement_direction.x
+		velocity.z = last_movement_direction.z
 		
 	look_forward(rotation_speed * delta)
 

--- a/third-person-controllers/third-person-controller/twist.gd
+++ b/third-person-controllers/third-person-controller/twist.gd
@@ -35,10 +35,6 @@ var pitch_input_mouse := 0.0
 var mouse_input_clamp := 1.0
 
 var last_camera_lag := 0.0
-var _last_movement_direction := Vector3.FORWARD
-
-func _on_player_last_movement_direction_updated(direction: Vector3) -> void:
-	_last_movement_direction = direction
 
 func _get_camera_look_vector() -> Vector2:
 	var look_vector := Input.get_vector("look_left", "look_right", "look_down", "look_up")


### PR DESCRIPTION
# Branch Summary

> Generated by Gemini 2.0 Flash

## refactor-and-cleanup

Refactor: Simplify last movement direction handling.

The `last_movement_direction` signal and associated methods have been removed and replaced with a simple setter on the `last_movement_direction` variable. This change simplifies the code by directly updating the look direction when the movement direction changes.

### Changes
- Removed the `last_movement_direction_updated` signal from `third_person_controller.gd`.
- Removed `get_last_movement_direction()` and `set_last_movement_direction()` methods from `third_person_controller.gd`.
- Modified `last_movement_direction` in `third_person_controller.gd` to have a setter that updates `_look_direction`.
- Replaced calls to `set_last_movement_direction()` with direct assignments to `last_movement_direction` in `third_person_controller.gd`.
- Removed the `_on_player_last_movement_direction_updated` function from `twist.gd`.
- Removed the connection to the `last_movement_direction_updated` signal in `third-person-controller.tscn`.

### Impact
- Simplifies the code by removing the signal/slot mechanism for updating the last movement direction.
- Reduces complexity and potential overhead related to signal emission.
- Any external components relying on the `last_movement_direction_updated` signal will no longer receive updates via that mechanism and will need to adapt to read the variable directly.