### PR TITLE
feat: Implement wall slide and jump

### DIFF
--- a/third-person-controllers/third-person-controller/state-machine/fall.gd
+++ b/third-person-controllers/third-person-controller/state-machine/fall.gd
@@ -3,11 +3,13 @@ extends ThirdPersonControllerState
 func _do_physics_process(delta: float) -> void:
 	# print("Fall _do_physics_process")
 	if tpc.is_start_dash():
-		finished.emit(DASH, generate_delta_dictionary(delta, "_do_phsics_process"))
+		finished.emit(DASH, generate_delta_dictionary(delta, "_do_physics_process"))
 		return
 	elif tpc.is_on_floor():
-		finished.emit(IWR, generate_delta_dictionary(delta, "_do_phsics_process"))
+		finished.emit(IWR, generate_delta_dictionary(delta, "_do_physics_process"))
 		return
+	elif tpc.is_wall_slide and tpc.is_on_wall():
+		finished.emit(WALL_SLIDE, generate_delta_dictionary(delta, "do_physics_process"))
 	
 	tpc._do_fall(delta)
 	if tpc.is_mid_air_movement:

--- a/third-person-controllers/third-person-controller/state-machine/state.gd
+++ b/third-person-controllers/third-person-controller/state-machine/state.gd
@@ -4,6 +4,8 @@ const IWR := "IdleWalkRun"
 const JUMP := "Jump"
 const FALL := "Fall"
 const DASH := "Dash"
+const WALL_SLIDE := "WallSlide"
+const WALL_JUMP := "WallJump"
 
 var tpc: ThirdPersonController
 

--- a/third-person-controllers/third-person-controller/state-machine/wall_jump.gd
+++ b/third-person-controllers/third-person-controller/state-machine/wall_jump.gd
@@ -1,0 +1,15 @@
+extends ThirdPersonControllerState
+
+func _do_physics_process(delta) -> void:
+	if tpc.is_on_floor():
+		finished.emit(IWR, generate_delta_dictionary(delta, "_do_physics_process"))
+		return
+	elif tpc.is_on_wall():
+		finished.emit(WALL_SLIDE, generate_delta_dictionary(delta, "_do_physics_process"))
+		return
+	elif tpc.is_start_dash():
+		finished.emit(DASH, generate_delta_dictionary(delta, "_do_physics_process"))
+		return
+	
+	tpc._do_fall(delta)
+	tpc.move_and_slide()

--- a/third-person-controllers/third-person-controller/state-machine/wall_jump.gd.uid
+++ b/third-person-controllers/third-person-controller/state-machine/wall_jump.gd.uid
@@ -1,0 +1,1 @@
+uid://cedv2cnl3b2l

--- a/third-person-controllers/third-person-controller/state-machine/wall_slide.gd
+++ b/third-person-controllers/third-person-controller/state-machine/wall_slide.gd
@@ -1,0 +1,22 @@
+extends ThirdPersonControllerState
+
+func _enter(_p, _d = {}) -> void:
+	tpc.velocity.y = tpc.wall_slide_velocity
+
+func _do_physics_process(delta) -> void:
+	if tpc.is_on_floor():
+		finished.emit(IWR, generate_delta_dictionary(delta, "_do_physics_process"))
+		return
+	elif !tpc.is_on_wall():
+		finished.emit(FALL, generate_delta_dictionary(delta, "_do_physics_process"))
+		return
+	elif Input.is_action_pressed("jump"):
+		tpc.last_movement_direction = tpc.get_wall_normal() * tpc.speed
+		tpc.look_forward(1.0)
+		tpc.velocity = tpc.get_wall_normal() * tpc.speed
+		tpc.velocity.y = tpc.jump_velocity
+		tpc.move_and_slide()
+		finished.emit(WALL_JUMP)
+		return
+	
+	tpc.move_and_slide()

--- a/third-person-controllers/third-person-controller/state-machine/wall_slide.gd.uid
+++ b/third-person-controllers/third-person-controller/state-machine/wall_slide.gd.uid
@@ -1,0 +1,1 @@
+uid://cnmqqpll8qs3o

--- a/third-person-controllers/third-person-controller/third-person-controller.tscn
+++ b/third-person-controllers/third-person-controller/third-person-controller.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=18 format=3 uid="uid://oxyumaw1iadk"]
+[gd_scene load_steps=20 format=3 uid="uid://oxyumaw1iadk"]
 
 [ext_resource type="Script" uid="uid://d0ixx1sbbgv3y" path="res://third-person-controller/third_person_controller.gd" id="1_raonk"]
 [ext_resource type="Script" uid="uid://drcjvbdv55mrc" path="res://third-person-controller/state-machine/state_machine.gd" id="2_hq6i3"]
@@ -7,7 +7,9 @@
 [ext_resource type="Script" uid="uid://dq5nuw1p8r2m5" path="res://third-person-controller/state-machine/jump.gd" id="4_i6k8c"]
 [ext_resource type="Script" uid="uid://d3bo8vc5ho77h" path="res://third-person-controller/state-machine/fall.gd" id="5_otdli"]
 [ext_resource type="Script" uid="uid://dnyuk46th8ggg" path="res://third-person-controller/state-machine/dash.gd" id="7_yid2g"]
+[ext_resource type="Script" uid="uid://cnmqqpll8qs3o" path="res://third-person-controller/state-machine/wall_slide.gd" id="8_er4ly"]
 [ext_resource type="PackedScene" uid="uid://cq0bb4yx3m4ay" path="res://health-bar/health-bar-3d.tscn" id="8_mditm"]
+[ext_resource type="Script" uid="uid://cedv2cnl3b2l" path="res://third-person-controller/state-machine/wall_jump.gd" id="9_kdpxr"]
 
 [sub_resource type="Gradient" id="Gradient_fm20d"]
 colors = PackedColorArray(0, 0.623711, 0.62869, 1, 1, 1, 1, 1)
@@ -41,6 +43,7 @@ height = 0.95
 [node name="Player" type="CharacterBody3D"]
 collision_layer = 2
 script = ExtResource("1_raonk")
+is_wall_slide = true
 
 [node name="Model" type="Node3D" parent="."]
 
@@ -91,6 +94,12 @@ script = ExtResource("7_yid2g")
 one_shot = true
 
 [node name="Cooldown" type="Timer" parent="StateMachine/Dash"]
+
+[node name="WallSlide" type="Node" parent="StateMachine"]
+script = ExtResource("8_er4ly")
+
+[node name="WallJump" type="Node" parent="StateMachine"]
+script = ExtResource("9_kdpxr")
 
 [node name="HealthBar3d" parent="." instance=ExtResource("8_mditm")]
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 1.29492, 0)

--- a/third-person-controllers/third-person-controller/third_person_controller.gd
+++ b/third-person-controllers/third-person-controller/third_person_controller.gd
@@ -29,6 +29,8 @@ func _ready() -> void:
 @export var dash_cooldown := 0.3
 @export var is_dash_hold := false
 @export var is_mid_air_movement := true
+@export var is_wall_slide := false
+@export var wall_slide_velocity := -0.5
 
 var is_dash_ready := true
 var last_movement_direction := Vector3.FORWARD:
@@ -55,7 +57,7 @@ func look_forward(weight: float) -> void:
 func _do_dash() -> void:
 	var input_vector := Input.get_vector("move_left", "move_right", "move_up", "move_down")
 	var dash_direction := (
-		Vector3(input_vector.x, 0, input_vector.y).rotated(Vector3.UP, twist_pivot.rotation.y) if input_vector else
+		Vector3(input_vector.x, 0, input_vector.y).rotated(Vector3.UP, twist_pivot.rotation.y) if is_on_floor() and input_vector else
 		Vector3.FORWARD.rotated(Vector3.UP, model.rotation.y)
 	).normalized()
 	


### PR DESCRIPTION
# Branch Summary

> Generated by Gemini 2.0 Flash

## add-wall-slide-and-jump

Implements Wall Slide and Wall Jump

This commit introduces wall sliding and wall jumping mechanics to the third-person controller.  It adds new states for these behaviors and integrates them into the existing state machine, enabling the player to slide down and jump off walls.

### Changes
- Added `WALL_SLIDE` and `WALL_JUMP` constants to `state.gd` to represent the new states.
- Created new `wall_slide.gd` and `wall_jump.gd` state scripts, defining their respective behaviors. The `wall_slide` state handles the wall sliding movement and transitions, while the `wall_jump` state handles the jump off the wall.
- Modified `fall.gd` to transition to the `WALL_SLIDE` state when the character is on a wall and `is_wall_slide` is true.
- Added `is_wall_slide` and `wall_slide_velocity` properties to `third_person_controller.gd`.
- Modified `_do_dash` in `third_person_controller.gd` to check if `is_on_floor` before dashing.
- Added `WallSlide` and `WallJump` nodes to the `StateMachine` in `third_person_controller.tscn`, assigning the respective scripts.

### Impact
- The character can now enter a `WallSlide` state when falling against a wall if `is_wall_slide` is enabled.
- From the `WallSlide` state, the character can jump off the wall, transitioning to the `WallJump` state or other states like `IWR` (IdleWalkRun) or `FALL`.
- Movement logic has been added to allow the wall jump.
- No breaking changes are apparent.

## Dev Note

Unlike the fall state, the player cannot move in the XZ plane during a wall jump to help prevent the player from being able to turn back to the wall and infinitely climb. For games where wall jumping is a core mechanic, a more elegant solution may be required.