### PR TITLE
fix: Add missing return

### DIFF
--- a/third-person-controllers/third-person-controller/state-machine/fall.gd
+++ b/third-person-controllers/third-person-controller/state-machine/fall.gd
@@ -10,6 +10,7 @@ func _do_physics_process(delta: float) -> void:
 		return
 	elif tpc.is_wall_slide and tpc.is_on_wall():
 		finished.emit(WALL_SLIDE, generate_delta_dictionary(delta, "do_physics_process"))
+		return
 	
 	tpc._do_fall(delta)
 	if tpc.is_mid_air_movement:


### PR DESCRIPTION
# Branch Summary

> Generated by Gemini 2.0 Flash

## fix-missing-return

Fix: Added missing return in Fall state.

A `return` statement was added to the `fall.gd` script to prevent further execution when the character enters a wall slide state. This fixes a potential bug where the fall logic could continue executing even during a wall slide.

### Changes
- Added a `return` statement within the `_do_physics_process` function in `fall.gd`.
- The `return` statement is placed after the `finished.emit(WALL_SLIDE, generate_delta_dictionary(delta, "do_physics_process"))` line, ensuring the function exits when the character is wall sliding.
- Modified components/files: `third-person-controllers/third-person-controller/state-machine/fall.gd`

### Impact
- Behavioral change: The `_do_physics_process` function in the Fall state now correctly exits when the character enters a wall slide, preventing unintended fall logic execution during wall sliding.
- Dependencies affected: None.
- No breaking changes.
- No performance implications.